### PR TITLE
refactor: rename `EnqueueDeviceActivation` to `DeviceHandler`

### DIFF
--- a/handlers/deviceHandler.go
+++ b/handlers/deviceHandler.go
@@ -144,7 +144,7 @@ func startDeviceActivator() {
 }
 
 // This is the Gin route handler which enqueues the request into the activator queue
-func EnqueueDeviceActivation(c *gin.Context) {
+func DeviceHandler(c *gin.Context) {
 	// Ensure the device activator starts only once in the application's lifetime
 	once.Do(startDeviceActivator)
 

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 			})
 		})
 
-		protected.POST("/activate", handlers.EnqueueDeviceActivation)
+		protected.POST("/activate", handlers.DeviceHandler) // Activate a device with a duration
 	}
 
 	// Step 9: Start the HTTP server


### PR DESCRIPTION
Renamed the Gin route handler and its function from `EnqueueDeviceActivation` to `DeviceHandler` for clarity and consistency. Updated the route registration in `main.go` to use the new function name.