### PR TITLE
feat: add device status endpoint and improve WebSocket auth

### DIFF
--- a/handlers/deviceStatusHandler.go
+++ b/handlers/deviceStatusHandler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/musabgulfam/pumplink-backend/database"
+	"github.com/musabgulfam/pumplink-backend/models"
+)
+
+func DeviceStatusHandler(c *gin.Context) {
+	// Extract device ID from the URL parameter
+	deviceID := c.Param("id")
+
+	db := database.GetDB()
+
+	// Fetch the device status from the database
+	var deviceModel = models.Device{}
+	if err := db.Where("id = ?", deviceID).First(&deviceModel).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Device not found"})
+		return
+	}
+
+	if deviceModel.State == "OFF" {
+		c.JSON(http.StatusOK, gin.H{"device_id": deviceID, "status": "OFF"})
+		return
+	}
+
+	// Find latest ON log entry for this device
+	var latestLog models.DeviceLog
+	if err := db.
+		Joins("JOIN device_sessions ON device_sessions.id = device_logs.session_id").
+		Where("device_sessions.device_id = ? AND device_logs.state = ?", deviceID, "ON").
+		Order("device_logs.changed_at DESC").
+		First(&latestLog).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not fetch latest log"})
+		return
+	}
+
+	activeUntil := time.Until(latestLog.CreatedAt.Add(*latestLog.Duration))
+
+	log.Printf("duration: %v", latestLog.Duration)
+	log.Printf("log created at: %v", latestLog.CreatedAt)
+
+	// Return the device status as JSON
+	c.JSON(http.StatusOK, gin.H{"device_id": deviceID, "status": deviceModel.State, "active_until": time.Unix(int64(activeUntil.Seconds()), int64(activeUntil.Nanoseconds())).Format(time.RFC3339)})
+}

--- a/handlers/ws.go
+++ b/handlers/ws.go
@@ -33,7 +33,10 @@ func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 	_, err = utils.ValidateJWT(token)
 	if err != nil {
 		log.Println("Invalid token, closing connection")
-		conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Invalid token"))
+		closeMsg := websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Unauthorized: Invalid token")
+		conn.WriteMessage(websocket.CloseMessage, closeMsg)
+		conn.Close()
+		log.Println("Connection closed due to invalid token")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -100,9 +100,8 @@ func main() {
 			})
 
 			protected.POST("/activate", handlers.DeviceHandler) // Activate a device with a duration
-			// protected.GET("/ws", func(c *gin.Context) {
-			// 	handlers.WebSocketHandler(c.Writer, c.Request)
-			// }) // WebSocket endpoint
+
+			protected.GET("device/:id/status", handlers.DeviceStatusHandler)
 		}
 
 		// Step 9: Start the HTTP server

--- a/models/deviceLog.go
+++ b/models/deviceLog.go
@@ -8,11 +8,6 @@ import (
 
 type DeviceLog struct {
 	gorm.Model
-	ID uint `gorm:"primaryKey"`
-	// DeviceID      uint           `gorm:"not null"`
-	// Device        Device         `gorm:"foreignKey:DeviceID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
-	// UserID        uint           `gorm:"not null"`
-	// User          User           `gorm:"foreignKey:UserID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
 	ChangedAt     time.Time      // When change occurred
 	State         string         // e.g., "ON", "OFF"
 	Duration      *time.Duration // optional: how long it stayed in that state (nullable)


### PR DESCRIPTION
Introduces a new GET endpoint to fetch device status by ID, including active state and duration, via DeviceStatusHandler. Improves WebSocketHandler by closing connections on invalid JWTs and logging the closure. Also cleans up the DeviceLog model by removing commented-out fields.