### PR TITLE
feat: add role-based access control middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/musabgulfam/pumplink-backend/database"
 	"github.com/musabgulfam/pumplink-backend/handlers"
 	"github.com/musabgulfam/pumplink-backend/middleware"
+	"github.com/musabgulfam/pumplink-backend/models"
 	"github.com/musabgulfam/pumplink-backend/mqtt"
 	wsmanager "github.com/musabgulfam/pumplink-backend/realtime"
 
@@ -99,7 +100,7 @@ func main() {
 				})
 			})
 
-			protected.POST("/activate", handlers.DeviceHandler) // Activate a device with a duration
+			protected.POST("/activate", middleware.RoleMiddleware(models.RoleUser, models.RoleAdmin), handlers.DeviceHandler) // Activate a device with a duration
 
 			protected.GET("device/:id/status", handlers.DeviceStatusHandler)
 		}

--- a/middleware/role.go
+++ b/middleware/role.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/musabgulfam/pumplink-backend/database"
+	"github.com/musabgulfam/pumplink-backend/models"
+)
+
+func RoleMiddleware(allowedRoles ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		// Get the user ID from the context
+		userID, err := c.Get("userID")
+		if !err {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			return
+		}
+
+		// Fetch the user from the database using the userID
+		var user models.User
+		if err := database.DB.Where("id = ?", userID).First(&user).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "User not found"})
+			return
+		}
+
+		// Check if the user's role is in the allowed roles
+		for _, role := range allowedRoles {
+			if user.Role == role {
+				c.Next() // User has the required role, continue processing the request
+				return
+			}
+		}
+
+		// If we reach here, the user does not have the required role
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Forbidden: insufficient permissions"})
+	}
+}

--- a/models/role.go
+++ b/models/role.go
@@ -1,0 +1,7 @@
+package models
+
+const (
+    RolePending = "pending"
+    RoleUser    = "user"
+    RoleAdmin   = "admin"
+)

--- a/models/user.go
+++ b/models/user.go
@@ -10,6 +10,7 @@ type User struct {
 	ID       uint   `json:"id" gorm:"primaryKey"`
 	Email    string `json:"email" gorm:"uniqueIndex;not null"`
 	Password string `json:"-" gorm:"not null"`
+	Role     string `gorm:"default:'pending'"` // Default role is 'pending'
 }
 
 func (u *User) CheckPassword(password string) bool {


### PR DESCRIPTION
Introduced `RoleMiddleware` to restrict access to certain endpoints based on user roles. Added role constants in `models/role.go` and updated the `User` model to include a `Role` field with a default value. Applied the middleware to the device activation endpoint to allow only users with 'user' or 'admin' roles.