### PR TITLE
refactor: WebSocket and MQTT integration

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,9 +10,7 @@ import (
 	"github.com/musabgulfam/pumplink-backend/middleware"
 	"github.com/musabgulfam/pumplink-backend/models"
 	"github.com/musabgulfam/pumplink-backend/mqtt"
-	wsmanager "github.com/musabgulfam/pumplink-backend/realtime"
 
-	mqttlib "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 )
@@ -51,22 +49,13 @@ func main() {
 	}
 	log.Println("Database connected successfully")
 
-	if err := mqtt.Connect(fmt.Sprintf("%s://%s:%d", cfg.MQTTProtocol, cfg.MQTTHost, cfg.MQTTPort)); err != nil { // Connect to the MQTT broker
-		log.Fatal("MQTT connection error: ", err) // If error, log and exit
+	if err := mqtt.Connect(fmt.Sprintf("%s://%s:%d", cfg.MQTTProtocol, cfg.MQTTHost, cfg.MQTTPort)); err != nil {
+		log.Fatal("MQTT connection error: ", err)
 	}
 	log.Println("Connected to MQTT broker successfully")
 
-	// Subscribe to all device status topics
-	mqtt.Subscribe("device/+/status", func(client mqttlib.Client, msg mqttlib.Message) {
-		topic := msg.Topic()
-		payload := string(msg.Payload())
-
-		log.Printf("MQTT message: %s -> %s\n", topic, payload)
-
-		// Here we would figure out which user this device belongs to (Start here 12th August 2025)
-		// userID := findUserByDevice(topic)
-		wsmanager.Broadcast(payload)
-	})
+	// Subscribe to all device status topics (encapsulated)
+	mqtt.SubscribeToDeviceStatus()
 
 	// Step 5: Initialize the HTTP server using Gin framework
 	r := gin.Default()

--- a/mqtt/subscriber.go
+++ b/mqtt/subscriber.go
@@ -1,0 +1,20 @@
+package mqtt
+
+import (
+	"log"
+
+	mqttlib "github.com/eclipse/paho.mqtt.golang"
+	wsmanager "github.com/musabgulfam/pumplink-backend/services"
+)
+
+// SubscribeToDeviceStatus subscribes to all device status topics and broadcasts updates to WebSocket clients.
+func SubscribeToDeviceStatus() {
+	Subscribe("device/+/status", func(client mqttlib.Client, msg mqttlib.Message) {
+		topic := msg.Topic()
+		payload := string(msg.Payload())
+
+		log.Printf("MQTT message: %s -> %s\n", topic, payload)
+		// Broadcast the message to all WebSocket clients
+		wsmanager.Broadcast(payload)
+	})
+}

--- a/services/websocket.go
+++ b/services/websocket.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"log"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type WSManager struct {
+	clients      map[*websocket.Conn]bool
+	mu           sync.Mutex
+	latestStatus []byte
+}
+
+var manager = &WSManager{
+	clients: make(map[*websocket.Conn]bool),
+}
+
+// AddClient registers a new client and sends the latest status if available
+func AddClient(conn *websocket.Conn) {
+	manager.mu.Lock()
+	manager.clients[conn] = true
+	latest := manager.latestStatus
+	manager.mu.Unlock()
+
+	// Send the latest status to the new client
+	if latest != nil {
+		if err := conn.WriteMessage(websocket.TextMessage, latest); err != nil {
+			log.Printf("[WEBSOCKET] Failed to send latest status to new client: %v", err)
+		}
+	}
+}
+
+// RemoveClient unregisters a client
+func RemoveClient(conn *websocket.Conn) {
+	manager.mu.Lock()
+	delete(manager.clients, conn)
+	manager.mu.Unlock()
+}
+
+// Broadcast sends a message to all connected clients and stores it as the latest status
+func Broadcast(msg string) {
+	manager.mu.Lock()
+	manager.latestStatus = []byte(msg)
+	for client := range manager.clients {
+		if err := client.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+			log.Printf("[WEBSOCKET] broadcast error: %v", err)
+			client.Close()
+			delete(manager.clients, client)
+		}
+	}
+	manager.mu.Unlock()
+}

--- a/utils/jwt.go
+++ b/utils/jwt.go
@@ -45,6 +45,5 @@ func ValidateJWT(tokenStr string) (string, error) {
 	}
 	userID := fmt.Sprintf("%.0f", userIDFloat)
 
-	log.Printf("[JWT] Token valid for user: %s", userID)
 	return userID, nil
 }


### PR DESCRIPTION
Moved WebSocket client management to a new services package and encapsulated MQTT device status subscription logic in `mqtt/subscriber.go`. WebSocket handler now validates JWT, adds clients, and sends the latest status on connect. Improved logging and removed direct MQTT-to-WebSocket coupling from main.go for better modularity.