### PR TITLE
fix: `active_until` calculation in device status handler

### DIFF
--- a/handlers/deviceStatus.go
+++ b/handlers/deviceStatus.go
@@ -39,11 +39,14 @@ func DeviceStatusHandler(c *gin.Context) {
 		return
 	}
 
-	activeUntil := time.Until(latestLog.CreatedAt.Add(*latestLog.Duration))
-
 	log.Printf("duration: %v", latestLog.Duration)
 	log.Printf("log created at: %v", latestLog.CreatedAt)
 
+	activeUntilTime := latestLog.CreatedAt.Add(*latestLog.Duration)
 	// Return the device status as JSON
-	c.JSON(http.StatusOK, gin.H{"device_id": deviceID, "status": deviceModel.State, "active_until": time.Unix(int64(activeUntil.Seconds()), int64(activeUntil.Nanoseconds())).Format(time.RFC3339)})
+	c.JSON(http.StatusOK, gin.H{
+		"device_id":    deviceID,
+		"status":       deviceModel.State,
+		"active_until": activeUntilTime.Format(time.RFC3339),
+	})
 }


### PR DESCRIPTION
Refactored the calculation of the `active_until` field to use the correct timestamp instead of a duration. The handler now returns the proper RFC3339 formatted time for `active_until`.