### PR TITLE
fix: add QoS parameter to MQTT Publish function

### DIFF
--- a/services/device.go
+++ b/services/device.go
@@ -131,7 +131,7 @@ func (ds *DeviceService) activatorLoop() {
 		}
 
 		// Publish ON command to device MQTT broker
-		Publish(MQTTTopicDeviceControl, "on") // Send ON command
+		Publish(MQTTTopicDeviceControl, "on", 2) // Send ON command
 
 		// Turn ON the device
 		if err := db.Model(&device).Update("state", "ON").Error; err != nil {
@@ -193,7 +193,7 @@ func (ds *DeviceService) activatorLoop() {
 		ds.activeActivationsMu.Unlock()
 
 		// Publish OFF command to device MQTT broker
-		Publish(MQTTTopicDeviceControl, "off") // Send OFF command
+		Publish(MQTTTopicDeviceControl, "off", 2) // Send OFF command
 
 		// Turn OFF the device
 		if err := db.Model(&device).Update("state", "OFF").Error; err != nil {

--- a/services/mqtt.go
+++ b/services/mqtt.go
@@ -52,8 +52,8 @@ func Subscribe(topic string, callback mqttlib.MessageHandler) error { // Subscri
 	return nil // Success
 }
 
-func Publish(topic string, payload interface{}) error { // Publish a message to a topic
-	token := Client.Publish(topic, 0, false, payload) // Publish message
-	token.Wait()                                      // Wait for publish to complete
-	return token.Error()                              // Return error if any
+func Publish(topic string, payload interface{}, qos byte) error { // Publish a message to a topic
+	token := Client.Publish(topic, qos, false, payload) // Publish message
+	token.Wait()                                        // Wait for publish to complete
+	return token.Error()                                // Return error if any
 }


### PR DESCRIPTION
Updated the Publish function in `mqtt.go` to accept a `QoS` parameter, allowing callers to specify the desired Quality of Service level. Updated device.go to use the new parameter when sending ON and OFF commands to devices.