### PR TITLE
fix: change push notification sound to `notification`

### DIFF
--- a/services/notification.go
+++ b/services/notification.go
@@ -17,7 +17,7 @@ func SendPushNotification(token, title, body string, data map[string]string) err
 		Title:    title,
 		Body:     body,
 		Data:     data,
-		Sound:    "default",
+		Sound:    "notification",
 		Priority: expo.DefaultPriority,
 	}
 	_, err := client.Publish(&msg)


### PR DESCRIPTION
Updated the Sound field in `SendPushNotification` from `default` to `notification` to modify the notification sound behaviour.