### PR TITLE
chore: add admin push notification support for device events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,6 @@ DB_NAME=DB_NAME
 
 # Timezone Configuration
 TZ=Asia/Karachi
+
+# Expo Push Notification Token
+EXPO_PUSH_TOKEN=expo_push_token


### PR DESCRIPTION
Introduced `SendDevicePushNotificationToAdmin` to send device event notifications directly to an admin/user using a token from environment variables. Updated device service logic to use this new function for admin-specific notifications instead of broadcasting to all users. Also updated `.env.example` to include `EXPO_PUSH_TOKEN`.